### PR TITLE
handle KeyError: transcript_id not found

### DIFF
--- a/sashimi-plot.py
+++ b/sashimi-plot.py
@@ -3,7 +3,7 @@
 # Import modules
 from argparse import ArgumentParser
 import subprocess as sp
-import sys, re, copy, os, codecs
+import sys, re, copy, os, codecs, gzip
 from collections import OrderedDict
 
 def define_options():
@@ -285,8 +285,14 @@ def read_gtf(f, c):
                         el_chr, _, el, el_start, el_end, _, strand, _, tags = line.strip().split("\t")
                         if el_chr != chr:
                                 continue
+                        if el not in ("transcript", "exon"):
+                                continue
                         d = dict(kv.strip().split(" ") for kv in tags.strip(";").split("; "))
-                        transcript_id = d["transcript_id"]
+                        try:
+                                transcript_id = d["transcript_id"]
+                        except KeyError as e:
+                                print(line)
+                                exit(e)
                         el_start, el_end = int(el_start) -1, int(el_end)
                         strand = '"' + strand + '"'
                         if el == "transcript":

--- a/sashimi-plot.py
+++ b/sashimi-plot.py
@@ -278,7 +278,7 @@ def read_gtf(f, c):
         transcripts = OrderedDict()
         chr, start, end = parse_coordinates(c)
         end = end -1
-        with open(f) as openf:
+        with gzip.open(f, "rt") if f.endswith(".gz") else open(f, "r") as openf:
                 for line in openf:
                         if line.startswith("#"):
                                 continue


### PR DESCRIPTION
1. Genes don't have transcript_id, therefore,  just try to get transcript_id from transcript and exon. 
2. add try-catch to "transcript_id" to throw a better error message
3. using gzip to handle the gzipped  gtf file

Still strong recommend using pysam to handle the IO of bam file